### PR TITLE
Add profile pages: About / Experience / Research / Publications

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ minimal_mistakes_skin    : "dark" # "air", "aqua", "contrast", "default", "dirt"
 locale                   : "en-US"
 title                    : "Jiyeon's Voyage"
 title_separator          : "|"
-subtitle                 : "A Belated Journal of Prospective Dr. Kim" # site tagline that appears below site title in masthead
+subtitle                 : "A Belated Journal of Dr. Kim" # site tagline that appears below site title in masthead
 name                     : "Jiyeon Kim"
 description              : "All records of my research and self-improvement."
 url                      : "https://jiyeon914.github.io"
@@ -91,66 +91,54 @@ og_image                 : # Open Graph/Twitter default site image
 # For specifying social profiles
 # - https://developers.google.com/structured-data/customize/social-profiles
 social:
-  type                   : # Person or Organization (defaults to Person)
-  name                   : # If the user or organization name differs from the site's name
-  links: # An array of links to social media profiles
+  type                   : Person
+  name                   : "Jiyeon Kim"
+  links:
+    - "https://github.com/jiyeon914"
+    - "https://www.linkedin.com/in/jiyeon-kim-b4ba19314/"
+    - "https://orcid.org/0000-0001-6668-1951"
 
 # Analytics
 analytics:
   provider               : "google-gtag" # false (default), "google", "google-universal", "google-gtag", "custom"
   google:
     tracking_id          : "G-CRY3B1VTLT"
-    anonymize_ip         : flase # true, false (default)
+    anonymize_ip         : false # true, false (default)
 
 
 # Site Author
 author:
   name             : "Jiyeon Kim"
-  avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
-  bio              : "My Github blog starting from scratch: Recording everything from daily life to my research."
+  avatar           : "/assets/images/avatar.svg"
+  bio              : "AI Scientist at LG CNS · PhD in Fluid Mechanics · Bridging CFD and deep learning"
   location         : "Seoul, Republic of Korea"
   email            : # "jykim3994@gmail.com" 아래 link랑 같이 노출되어서 생략
   links:
     - label: "Email"
       icon: "fas fa-fw fa-envelope-square"
       url: "mailto:jykim3994@gmail.com"
-    - label: "Website"
-      icon: "fas fa-fw fa-link"
-      # url: "https://your-website.com"
-    - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      # url: "https://twitter.com/"
-    - label: "Facebook"
-      icon: "fab fa-fw fa-facebook-square"
-      # url: "https://facebook.com/"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: "https://github.com/jiyeon914"
-    - label: "Instagram"
-      icon: "fab fa-fw fa-instagram"
-      url: "https://www.instagram.com/jiyeonrina/"
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/jiyeon-kim-b4ba19314/"
+    - label: "ORCID"
+      icon: "fab fa-fw fa-orcid"
+      url: "https://orcid.org/0000-0001-6668-1951"
 
 # Site Footer
 footer:
   links:
-    - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      # url:
-    - label: "Facebook"
-      icon: "fab fa-fw fa-facebook-square"
-      # url:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: "https://github.com/jiyeon914"
-    - label: "GitLab"
-      icon: "fab fa-fw fa-gitlab"
-      # url:
-    - label: "Bitbucket"
-      icon: "fab fa-fw fa-bitbucket"
-      # url:
-    - label: "Instagram"
-      icon: "fab fa-fw fa-instagram"
-      url: "https://www.instagram.com/jiyeonrina/"
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/jiyeon-kim-b4ba19314/"
+    - label: "ORCID"
+      icon: "fab fa-fw fa-orcid"
+      url: "https://orcid.org/0000-0001-6668-1951"
 
 
 # Reading Files
@@ -292,5 +280,12 @@ defaults:
       share: true
       related: true
       show_date: true
+  # _pages
+  - scope:
+      path: "_pages"
+      type: pages
+    values:
+      layout: single
+      author_profile: true
 
 date_format: "%Y-%m-%d (%a), %H:%M"

--- a/_config.yml
+++ b/_config.yml
@@ -110,7 +110,7 @@ analytics:
 author:
   name             : "Jiyeon Kim"
   avatar           : "/assets/images/avatar.svg"
-  bio              : "AI Scientist at LG CNS · PhD in Fluid Mechanics · Bridging CFD and deep learning"
+  bio              : "AI Scientist at LG CNS · Ph.D. in Fluid Mechanics · Bridging CFD and deep learning"
   location         : "Seoul, Republic of Korea"
   email            : # "jykim3994@gmail.com" 아래 link랑 같이 노출되어서 생략
   links:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,12 +1,12 @@
 # main links
 main:
-  - title: "Quick-Start Guide"
-    url: https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/
-  # - title: "About"
-  #   url: https://mmistakes.github.io/minimal-mistakes/about/
-  # - title: "Sample Posts"
-  #   url: /year-archive/
-  # - title: "Sample Collections"
-  #   url: /collection-archive/
-  # - title: "Sitemap"
-  #   url: /sitemap/
+  - title: "About"
+    url: /about/
+  - title: "Experience"
+    url: /experience/
+  - title: "Research"
+    url: /research/
+  - title: "Publications"
+    url: /publications/
+  - title: "Posts"
+    url: /

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,0 +1,17 @@
+---
+title: "About"
+permalink: /about/
+---
+
+안녕하세요, 김지연입니다. 유체역학과 딥러닝 사이를 오가며 만난 것들, 그리고 그 너머 일상의 단편을 천천히 기록하는 공간이에요.
+
+I'm an AI Scientist at **LG CNS**, currently working on the *Data Center Cooling Control AI Agent* — a system that bridges CFD-rooted thermal management with AI-driven control. I completed my **Ph.D. in Fluid Mechanics** at Yonsei University in August 2025 under Prof. Changhoon Lee, where my research centered on dynamics prediction of turbulent flows using generative and explainable deep-learning models.
+
+This site is a slow-paced journal — part research log, part personal voyage.
+
+### Contact
+
+- Email: [jykim3994@gmail.com](mailto:jykim3994@gmail.com)
+- ORCID: [0000-0001-6668-1951](https://orcid.org/0000-0001-6668-1951)
+- GitHub: [@jiyeon914](https://github.com/jiyeon914)
+- LinkedIn: [jiyeon-kim](https://www.linkedin.com/in/jiyeon-kim-b4ba19314/)

--- a/_pages/experience.md
+++ b/_pages/experience.md
@@ -1,0 +1,30 @@
+---
+title: "Experience"
+permalink: /experience/
+---
+
+## Education
+
+- **Ph.D. in Fluid Mechanics**, Yonsei University (Mar 2020 – Aug 2025)
+  - School of Mathematics and Computing (Computational Science and Engineering)
+  - Advisor: Prof. Changhoon Lee
+- **B.S. in Mechanical Engineering**, Yonsei University (Mar 2012 – Feb 2020)
+
+## Industry
+
+- **Professional AI Scientist**, LG CNS — Seoul, Republic of Korea (Jul 2025 – Present)
+  - Project: *Data Center Cooling Control AI Agent* (ongoing)
+
+## Academic Research
+
+- **Graduate Student Researcher**, TURBULENCE Lab, Yonsei University (Mar 2020 – Aug 2025)
+  - DNS and LES of 2D & 3D homogeneous isotropic turbulence; statistical analysis of turbulence data; deep-learning dynamics prediction across model families (CNN, U-Net, GAN, diffusion, FNO); scale-dependent analysis and explainable AI (XAI) for DL-based turbulence prediction.
+- **Undergraduate Research Intern**, TURBULENCE Lab, Yonsei University (Jan 2019 – Feb 2020)
+  - Numerical methods foundations for cavity flows; built a lid-driven cavity DNS solver in C; near-wall pressure prediction from off-wall velocity using MLP models.
+
+## Teaching
+
+- **Instructor**, CSE Undergraduate Research Program — CFD team (Summer/Winter 2022, Summer/Winter 2023)
+- **Teaching Assistant**, Yonsei University
+  - MEU3009: Undergraduate Research (Winter 2022)
+  - MEU4400: Independent Study (Spring 2024, Fall 2024)

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,0 +1,39 @@
+---
+title: "Publications"
+permalink: /publications/
+---
+
+> Author name in **bold** indicates me.
+
+## Journal Articles
+
+1. **Jiyeon Kim**, Changhoon Lee. "Dynamics prediction of isotropic turbulence using conditional diffusion probabilistic models." (In Preparation)
+2. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of two-dimensional decaying turbulence using generative adversarial networks." *Journal of Fluid Mechanics*, **981**, A19 (2024).
+3. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation modeling in wall-bounded turbulence." *Physics of Fluids*, **34**, 105132 (2022).
+4. (Domestic) Changhoon Lee, **Jiyeon Kim**, Jun Park, Junhyuk Kim. THEME 03 "Utilization of artificial intelligence for turbulence analysis." *Journal of the KSME*, **64**(4), 42–49 (2024).
+
+## Conference Proceedings — International
+
+1. **Jiyeon Kim**, Changhoon Lee. "Prediction of isotropic turbulence using conditional diffusion probabilistic models." *77th APS DFD*, Nov. 2024.
+2. **Jiyeon Kim**, Changhoon Lee. "A conditional diffusion model for prediction of 2D turbulence." *ICTAM 2024*, Aug. 2024.
+3. **Jiyeon Kim**, Changhoon Lee. "Application of denoising diffusion probabilistic models to turbulence prediction." *76th APS DFD*, Nov. 2023.
+4. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D decaying turbulence using generative adversarial networks." *75th APS DFD*, Nov. 2022.
+5. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of turbulent flows using deep learning." *TSFP12*, Jul. 2022.
+6. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation sub-grid scale modeling in turbulent channel flow." *75th APS DFD*, Nov. 2022.
+7. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation of wall-bounded turbulence." *TSFP12*, Jul. 2022.
+
+## Conference Proceedings — Domestic
+
+1. **Jiyeon Kim**, Changhoon Lee. "Turbulence prediction using conditional diffusion probabilistic models." *13th National Congress on Fluids Engineering (13NCFE)*, Jul. 2024.
+2. **Jiyeon Kim**, Changhoon Lee. "Application of denoising diffusion probabilistic model to turbulence problems." *KSME Annual Meeting 2023*, Nov. 2023.
+3. **Jiyeon Kim**, Changhoon Lee. "Effect of adversarial training to dynamics prediction of 2D turbulence." *KSME Fluid Engineering Division 2023 Spring Conference*, May 2023.
+4. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D decaying turbulence using generative adversarial networks." *12NCFE*, Jun. 2022.
+5. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D turbulence using deep learning." *KSCSE 2022 Spring Conference*, May 2022.
+6. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of turbulent flows using deep learning." *KSME Fluid Engineering Division 2021 Spring Conference*, Aug. 2021.
+7. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Advanced prediction of 2D turbulent flows using deep learning." *KSCFE 2021 Spring Conference*, May 2021.
+
+## Grants & Honors
+
+1. Merit Academic Paper Award — Academic Field of Natural Science, Jul. 2024.
+2. Graduate School Scholarship for Social Problem-Solving Courses — Design and Analysis of Energy System, Jun. 2021.
+3. 2021 CSE Best Poster Award — The Second Prize, May 2021.

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,25 @@
+---
+title: "Research"
+permalink: /research/
+---
+
+## Research Interests
+
+- **Fluid mechanics** — turbulence and CFD. High-fidelity fluid simulations and statistical analysis of turbulence data; GPU-accelerated CFD.
+- **Deep learning** — generative AI and explainable AI. Leading-edge DL models applied to time-series physical data; analyzing and explaining the working principles of DL models in turbulence prediction.
+
+## Topics
+
+- 2D & 3D homogeneous isotropic turbulence (DNS, LES)
+- Deep-learning dynamics prediction across model families: CNN → U-Net → GAN → conditional diffusion → FNO
+- Scale-dependent analysis and explainable AI (XAI) for DL-based turbulence prediction
+- GPU acceleration for CFD simulations
+
+## Funded Projects
+
+- **NRF Strategic Project** — *Deep learning of turbulence* (Mar 2020 – Feb 2022). Participant.
+- **NRF Mid-sized Research Project** — *Fundamental understanding and high-performance modeling of turbulent flows using deep learning* (Mar 2022 – Present). Participant.
+
+## Industrial Bridge
+
+At LG CNS, the same CFD + AI direction is being extended into a production setting through the *Data Center Cooling Control AI Agent* project — taking thermal/fluid-flow modeling that traditionally lives in offline simulation, and embedding it into an AI control loop for live data center operations.

--- a/assets/images/avatar.svg
+++ b/assets/images/avatar.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-label="JK initials avatar">
+  <circle cx="100" cy="100" r="100" fill="#2d3748"/>
+  <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="Georgia, 'Times New Roman', serif" font-size="92" font-weight="600" fill="#e2e8f0">JK</text>
+</svg>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  jekyll:
+    image: ruby:3.2
+    working_dir: /site
+    volumes:
+      - .:/site
+      - bundle_cache:/usr/local/bundle
+    ports:
+      - "4000:4000"
+      - "35729:35729"
+    command:
+      - bash
+      - -c
+      - bundle check || bundle install && bundle exec jekyll serve --host 0.0.0.0 --livereload --force_polling --incremental
+
+volumes:
+  bundle_cache:

--- a/docs/superpowers/plans/2026-05-11-profile-pages.md
+++ b/docs/superpowers/plans/2026-05-11-profile-pages.md
@@ -1,0 +1,560 @@
+# Profile Pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the 5-tab profile (About | Experience | Research | Publications | Posts) on `jiyeon914.github.io`, with a cleaned-up `_config.yml`, JK avatar SVG, and the navigation rewired to the new pages.
+
+**Architecture:** Static content additions on top of Minimal Mistakes 4.24. No theme-core changes. All edits at repo root; `docs/` (theme docs sample) is already excluded from the build via `_config.yml` line 185.
+
+**Tech Stack:** Jekyll 4.x + Minimal Mistakes 4.24, `ruby:3.2` in Docker (`docker-compose.yml`), Font Awesome brand icons (already configured by the theme).
+
+**Source spec:** `docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md`
+
+---
+
+## File Structure
+
+Files this plan creates:
+
+- `_pages/about.md` — About page (Korean greeting + English bio + contact)
+- `_pages/experience.md` — Chronological education/industry/research/teaching timeline
+- `_pages/research.md` — Thematic research interests, topics, projects, industrial bridge
+- `_pages/publications.md` — Journal articles, conference proceedings (intl + domestic), grants & honors
+- `assets/images/avatar.svg` — JK initials placeholder avatar
+
+Files this plan modifies:
+
+- `_config.yml` — subtitle, author block (avatar, bio, links), footer.links, social block, anonymize_ip typo, defaults
+- `_data/navigation.yml` — replace placeholder with 5-tab top nav
+
+Out of scope: anything under `docs/`, theme core (`_includes`, `_layouts`, `_sass`), the existing test post, the comments configuration (already set).
+
+---
+
+## Task 1: Clean up `_config.yml`
+
+**Files:**
+- Modify: `_config.yml`
+
+- [ ] **Step 1.1: Update site subtitle** (line ~21)
+
+Replace:
+```yaml
+subtitle                 : "A Belated Journal of Prospective Dr. Kim" # site tagline that appears below site title in masthead
+```
+with:
+```yaml
+subtitle                 : "A Belated Journal of Dr. Kim" # site tagline that appears below site title in masthead
+```
+
+- [ ] **Step 1.2: Fill in `social:` block** (around line 93)
+
+Replace:
+```yaml
+social:
+  type                   : # Person or Organization (defaults to Person)
+  name                   : # If the user or organization name differs from the site's name
+  links: # An array of links to social media profiles
+```
+with:
+```yaml
+social:
+  type                   : Person
+  name                   : "Jiyeon Kim"
+  links:
+    - "https://github.com/jiyeon914"
+    - "https://www.linkedin.com/in/jiyeon-kim-b4ba19314/"
+    - "https://orcid.org/0000-0001-6668-1951"
+```
+
+- [ ] **Step 1.3: Fix `anonymize_ip` typo** (line ~103)
+
+Replace:
+```yaml
+    anonymize_ip         : flase # true, false (default)
+```
+with:
+```yaml
+    anonymize_ip         : false # true, false (default)
+```
+
+- [ ] **Step 1.4: Set `author.avatar` and update `author.bio`** (lines ~109–110)
+
+Replace:
+```yaml
+  avatar           : # path of avatar image, e.g. "/assets/images/bio-photo.jpg"
+  bio              : "My Github blog starting from scratch: Recording everything from daily life to my research."
+```
+with:
+```yaml
+  avatar           : "/assets/images/avatar.svg"
+  bio              : "AI Scientist at LG CNS · PhD in Fluid Mechanics · Bridging CFD and deep learning"
+```
+
+- [ ] **Step 1.5: Replace `author.links` with the 4 approved links** (lines ~113–130)
+
+Replace the entire `author:` `links:` array (currently Email + 5 placeholder/active entries: Website, Twitter, Facebook, GitHub, Instagram) with exactly these four:
+
+```yaml
+  links:
+    - label: "Email"
+      icon: "fas fa-fw fa-envelope-square"
+      url: "mailto:jykim3994@gmail.com"
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/jiyeon914"
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/jiyeon-kim-b4ba19314/"
+    - label: "ORCID"
+      icon: "fab fa-fw fa-orcid"
+      url: "https://orcid.org/0000-0001-6668-1951"
+```
+
+- [ ] **Step 1.6: Replace `footer.links`** (around line 133+)
+
+Replace the entire `footer:` block (currently Twitter/Facebook/GitHub/GitLab/Bitbucket — four of those with empty `url`) with:
+
+```yaml
+# Site Footer
+footer:
+  links:
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/jiyeon914"
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/jiyeon-kim-b4ba19314/"
+    - label: "ORCID"
+      icon: "fab fa-fw fa-orcid"
+      url: "https://orcid.org/0000-0001-6668-1951"
+```
+
+- [ ] **Step 1.7: Add `_pages` scope to `defaults:`** (around line 282)
+
+The existing `defaults:` block has only the `_posts` entry. Append a `_pages` entry so the block becomes:
+
+```yaml
+defaults:
+  # _posts
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: single
+      author_profile: true
+      read_time: true
+      comments: true
+      share: true
+      related: true
+      show_date: true
+  # _pages
+  - scope:
+      path: "_pages"
+      type: pages
+    values:
+      layout: single
+      author_profile: true
+```
+
+Scoping the path to `_pages` means existing `index.html` at the repo root is not affected.
+
+- [ ] **Step 1.8: Verify build still succeeds**
+
+Run:
+```
+docker compose run --rm jekyll bundle exec jekyll build
+```
+
+Expected: exit 0. Pre-existing sass deprecation warnings from Minimal Mistakes vendor stylesheets are unrelated and OK. There should be **no new YAML parse errors and no new permalink-conflict warnings**.
+
+- [ ] **Step 1.9: Commit**
+
+```
+git add _config.yml
+git commit -m "Clean up _config.yml: subtitle, author/footer/social, defaults, typo"
+```
+
+---
+
+## Task 2: Add JK avatar SVG
+
+**Files:**
+- Create: `assets/images/avatar.svg`
+
+- [ ] **Step 2.1: Create the directory**
+
+```
+mkdir -p assets/images
+```
+
+- [ ] **Step 2.2: Write `assets/images/avatar.svg`**
+
+Content:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-label="JK initials avatar">
+  <circle cx="100" cy="100" r="100" fill="#2d3748"/>
+  <text x="50%" y="52%" text-anchor="middle" dominant-baseline="middle" font-family="Georgia, 'Times New Roman', serif" font-size="92" font-weight="600" fill="#e2e8f0">JK</text>
+</svg>
+```
+
+Dark slate background, light gray serif initials — readable on both dark and light skins.
+
+- [ ] **Step 2.3: Verify the asset is picked up by the build**
+
+```
+docker compose run --rm jekyll bundle exec jekyll build
+test -f _site/assets/images/avatar.svg && echo OK || echo MISSING
+```
+
+Expected: `OK`.
+
+- [ ] **Step 2.4: Commit**
+
+```
+git add assets/images/avatar.svg
+git commit -m "Add JK initials avatar SVG"
+```
+
+---
+
+## Task 3: Add About page
+
+**Files:**
+- Create: `_pages/about.md`
+
+- [ ] **Step 3.1: Write `_pages/about.md`**
+
+Content:
+
+```markdown
+---
+title: "About"
+permalink: /about/
+---
+
+안녕하세요, 김지연입니다. 유체역학과 딥러닝 사이를 오가며 만난 것들, 그리고 그 너머 일상의 단편을 천천히 기록하는 공간이에요.
+
+I'm an AI Scientist at **LG CNS**, currently working on the *Data Center Cooling Control AI Agent* — a system that bridges CFD-rooted thermal management with AI-driven control. I completed my **Ph.D. in Fluid Mechanics** at Yonsei University in August 2025 under Prof. Changhoon Lee, where my research centered on dynamics prediction of turbulent flows using generative and explainable deep-learning models.
+
+This site is a slow-paced journal — part research log, part personal voyage.
+
+### Contact
+
+- Email: [jykim3994@gmail.com](mailto:jykim3994@gmail.com)
+- ORCID: [0000-0001-6668-1951](https://orcid.org/0000-0001-6668-1951)
+- GitHub: [@jiyeon914](https://github.com/jiyeon914)
+- LinkedIn: [jiyeon-kim](https://www.linkedin.com/in/jiyeon-kim-b4ba19314/)
+```
+
+- [ ] **Step 3.2: Build and verify the page renders**
+
+```
+docker compose run --rm jekyll bundle exec jekyll build
+test -f _site/about/index.html && echo OK || echo MISSING
+grep -o '<title>[^<]*</title>' _site/about/index.html | head -1
+```
+
+Expected: `OK` and `<title>About | …</title>`.
+
+- [ ] **Step 3.3: Commit**
+
+```
+git add _pages/about.md
+git commit -m "Add About page"
+```
+
+---
+
+## Task 4: Add Experience page
+
+**Files:**
+- Create: `_pages/experience.md`
+
+- [ ] **Step 4.1: Write `_pages/experience.md`**
+
+Content:
+
+```markdown
+---
+title: "Experience"
+permalink: /experience/
+---
+
+## Education
+
+- **Ph.D. in Fluid Mechanics**, Yonsei University (Mar 2020 – Aug 2025)
+  - School of Mathematics and Computing (Computational Science and Engineering)
+  - Advisor: Prof. Changhoon Lee
+- **B.S. in Mechanical Engineering**, Yonsei University (Mar 2012 – Feb 2020)
+
+## Industry
+
+- **Professional AI Scientist**, LG CNS — Seoul, Republic of Korea (Jul 2025 – Present)
+  - Project: *Data Center Cooling Control AI Agent* (ongoing)
+
+## Academic Research
+
+- **Graduate Student Researcher**, TURBULENCE Lab, Yonsei University (Mar 2020 – Aug 2025)
+  - DNS and LES of 2D & 3D homogeneous isotropic turbulence; statistical analysis of turbulence data; deep-learning dynamics prediction across model families (CNN, U-Net, GAN, diffusion, FNO); scale-dependent analysis and explainable AI (XAI) for DL-based turbulence prediction.
+- **Undergraduate Research Intern**, TURBULENCE Lab, Yonsei University (Jan 2019 – Feb 2020)
+  - Numerical methods foundations for cavity flows; built a lid-driven cavity DNS solver in C; near-wall pressure prediction from off-wall velocity using MLP models.
+
+## Teaching
+
+- **Instructor**, CSE Undergraduate Research Program — CFD team (Summer/Winter 2022, Summer/Winter 2023)
+- **Teaching Assistant**, Yonsei University
+  - MEU3009: Undergraduate Research (Winter 2022)
+  - MEU4400: Independent Study (Spring 2024, Fall 2024)
+```
+
+- [ ] **Step 4.2: Build and verify**
+
+```
+docker compose run --rm jekyll bundle exec jekyll build
+test -f _site/experience/index.html && echo OK || echo MISSING
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4.3: Commit**
+
+```
+git add _pages/experience.md
+git commit -m "Add Experience page"
+```
+
+---
+
+## Task 5: Add Research page
+
+**Files:**
+- Create: `_pages/research.md`
+
+- [ ] **Step 5.1: Write `_pages/research.md`**
+
+Content:
+
+```markdown
+---
+title: "Research"
+permalink: /research/
+---
+
+## Research Interests
+
+- **Fluid mechanics** — turbulence and CFD. High-fidelity fluid simulations and statistical analysis of turbulence data; GPU-accelerated CFD.
+- **Deep learning** — generative AI and explainable AI. Leading-edge DL models applied to time-series physical data; analyzing and explaining the working principles of DL models in turbulence prediction.
+
+## Topics
+
+- 2D & 3D homogeneous isotropic turbulence (DNS, LES)
+- Deep-learning dynamics prediction across model families: CNN → U-Net → GAN → conditional diffusion → FNO
+- Scale-dependent analysis and explainable AI (XAI) for DL-based turbulence prediction
+- GPU acceleration for CFD simulations
+
+## Funded Projects
+
+- **NRF Strategic Project** — *Deep learning of turbulence* (Mar 2020 – Feb 2022). Participant.
+- **NRF Mid-sized Research Project** — *Fundamental understanding and high-performance modeling of turbulent flows using deep learning* (Mar 2022 – Present). Participant.
+
+## Industrial Bridge
+
+At LG CNS, the same CFD + AI direction is being extended into a production setting through the *Data Center Cooling Control AI Agent* project — taking thermal/fluid-flow modeling that traditionally lives in offline simulation, and embedding it into an AI control loop for live data center operations.
+```
+
+- [ ] **Step 5.2: Build and verify**
+
+```
+docker compose run --rm jekyll bundle exec jekyll build
+test -f _site/research/index.html && echo OK || echo MISSING
+```
+
+Expected: `OK`.
+
+- [ ] **Step 5.3: Commit**
+
+```
+git add _pages/research.md
+git commit -m "Add Research page"
+```
+
+---
+
+## Task 6: Add Publications page
+
+**Files:**
+- Create: `_pages/publications.md`
+
+- [ ] **Step 6.1: Write `_pages/publications.md`**
+
+Content:
+
+```markdown
+---
+title: "Publications"
+permalink: /publications/
+---
+
+> Author name in **bold** indicates me.
+
+## Journal Articles
+
+1. **Jiyeon Kim**, Changhoon Lee. "Dynamics prediction of isotropic turbulence using conditional diffusion probabilistic models." (In Preparation)
+2. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of two-dimensional decaying turbulence using generative adversarial networks." *Journal of Fluid Mechanics*, **981**, A19 (2024).
+3. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation modeling in wall-bounded turbulence." *Physics of Fluids*, **34**, 105132 (2022).
+4. (Domestic) Changhoon Lee, **Jiyeon Kim**, Jun Park, Junhyuk Kim. THEME 03 "Utilization of artificial intelligence for turbulence analysis." *Journal of the KSME*, **64**(4), 42–49 (2024).
+
+## Conference Proceedings — International
+
+1. **Jiyeon Kim**, Changhoon Lee. "Prediction of isotropic turbulence using conditional diffusion probabilistic models." *77th APS DFD*, Nov. 2024.
+2. **Jiyeon Kim**, Changhoon Lee. "A conditional diffusion model for prediction of 2D turbulence." *ICTAM 2024*, Aug. 2024.
+3. **Jiyeon Kim**, Changhoon Lee. "Application of denoising diffusion probabilistic models to turbulence prediction." *76th APS DFD*, Nov. 2023.
+4. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D decaying turbulence using generative adversarial networks." *75th APS DFD*, Nov. 2022.
+5. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of turbulent flows using deep learning." *TSFP12*, Jul. 2022.
+6. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation sub-grid scale modeling in turbulent channel flow." *75th APS DFD*, Nov. 2022.
+7. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation of wall-bounded turbulence." *TSFP12*, Jul. 2022.
+
+## Conference Proceedings — Domestic
+
+1. **Jiyeon Kim**, Changhoon Lee. "Turbulence prediction using conditional diffusion probabilistic models." *13th National Congress on Fluids Engineering (13NCFE)*, Jul. 2024.
+2. **Jiyeon Kim**, Changhoon Lee. "Application of denoising diffusion probabilistic model to turbulence problems." *KSME Annual Meeting 2023*, Nov. 2023.
+3. **Jiyeon Kim**, Changhoon Lee. "Effect of adversarial training to dynamics prediction of 2D turbulence." *KSME Fluid Engineering Division 2023 Spring Conference*, May 2023.
+4. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D decaying turbulence using generative adversarial networks." *12NCFE*, Jun. 2022.
+5. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D turbulence using deep learning." *KSCSE 2022 Spring Conference*, May 2022.
+6. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of turbulent flows using deep learning." *KSME Fluid Engineering Division 2021 Spring Conference*, Aug. 2021.
+7. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Advanced prediction of 2D turbulent flows using deep learning." *KSCFE 2021 Spring Conference*, May 2021.
+
+## Grants & Honors
+
+1. Merit Academic Paper Award — Academic Field of Natural Science, Jul. 2024.
+2. Graduate School Scholarship for Social Problem-Solving Courses — Design and Analysis of Energy System, Jun. 2021.
+3. 2021 CSE Best Poster Award — The Second Prize, May 2021.
+```
+
+- [ ] **Step 6.2: Build and verify**
+
+```
+docker compose run --rm jekyll bundle exec jekyll build
+test -f _site/publications/index.html && echo OK || echo MISSING
+grep -c "Journal of Fluid Mechanics" _site/publications/index.html
+grep -c "TSFP12" _site/publications/index.html
+grep -c "Merit Academic Paper Award" _site/publications/index.html
+```
+
+Expected: `OK`, and each grep returns at least `1` (one canonical reference from each of journal / intl conf / honors sections).
+
+- [ ] **Step 6.3: Commit**
+
+```
+git add _pages/publications.md
+git commit -m "Add Publications page"
+```
+
+---
+
+## Task 7: Replace top navigation with the 5 tabs
+
+**Files:**
+- Modify: `_data/navigation.yml`
+
+- [ ] **Step 7.1: Rewrite `_data/navigation.yml`**
+
+Replace the entire file (currently a placeholder "Quick-Start Guide" entry plus commented-out samples) with:
+
+```yaml
+# main links
+main:
+  - title: "About"
+    url: /about/
+  - title: "Experience"
+    url: /experience/
+  - title: "Research"
+    url: /research/
+  - title: "Publications"
+    url: /publications/
+  - title: "Posts"
+    url: /
+```
+
+- [ ] **Step 7.2: Build and verify the menu items render**
+
+```
+docker compose run --rm jekyll bundle exec jekyll build
+for t in About Experience Research Publications Posts; do
+  printf '%-13s ' "$t"
+  grep -c ">$t</a>" _site/index.html
+done
+```
+
+Expected: each tab title appears at least once in `_site/index.html` (the masthead nav is on every page).
+
+- [ ] **Step 7.3: Commit**
+
+```
+git add _data/navigation.yml
+git commit -m "Set 5-tab navigation: About/Experience/Research/Publications/Posts"
+```
+
+---
+
+## Task 8: Final verification
+
+No code changes here. This task confirms end-to-end correctness against the spec's verification section.
+
+- [ ] **Step 8.1: Clean build**
+
+```
+docker compose run --rm jekyll bundle exec jekyll build
+```
+
+Expected: exit 0, no new errors. (Pre-existing sass deprecation warnings unrelated.)
+
+- [ ] **Step 8.2: Serve and curl each page**
+
+```
+docker compose up -d
+sleep 8  # let serve come up if it was just restarted
+for p in '' about experience research publications; do
+  url="http://localhost:4000/${p}${p:+/}"
+  printf '%-50s ' "$url"
+  curl -sI "$url" | head -1
+done
+```
+
+Expected: `HTTP/1.1 200 OK` for all 5 URLs.
+
+- [ ] **Step 8.3: Visual check in the browser** at http://localhost:4000/about/
+
+Confirm:
+- Top nav shows exactly five tabs: About / Experience / Research / Publications / Posts (in that order).
+- Sidebar (left column on `/about/`) shows: name "Jiyeon Kim", JK avatar, the bio one-liner, location "Seoul, Republic of Korea", and four link icons (Email / GitHub / LinkedIn / ORCID) — no Website / Twitter / Facebook / Instagram.
+- Footer shows GitHub / LinkedIn / ORCID only.
+- /about/ shows Korean greeting, then English bio paragraph, then Contact list.
+- /publications/ shows all entries grouped under four headings.
+
+- [ ] **Step 8.4: Regression check — existing posts still work**
+
+The home page should still list `2024-03-27-first-test-upload`. Visit `/` and confirm the post card renders.
+
+- [ ] **Step 8.5: Branch summary**
+
+```
+git log --oneline main..feature/profile-pages
+git status
+```
+
+Expected: working tree clean. Branch holds the spec + per-task commits, ready for PR or local merge.
+
+---
+
+## Out of Scope (do not do in this plan)
+
+- Blog post authoring beyond the existing test post
+- Categories/tags taxonomy
+- Theme color/typography customization beyond what `_config.yml` already provides
+- Comments (utterances) live verification — deferred until the first real post
+- Analytics setup beyond fixing the existing typo
+- Full bilingual (Korean/English) page-switching — only the About greeting is in Korean
+- Pushing the branch or opening the PR (decide separately with the user)

--- a/docs/superpowers/specs/2026-05-11-blog-profile-pages-design-review.md
+++ b/docs/superpowers/specs/2026-05-11-blog-profile-pages-design-review.md
@@ -1,0 +1,236 @@
+# Review — Blog Profile Pages Design Spec
+
+**Date:** 2026-05-11
+**Reviewer:** Codex
+**Target:** `docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md`
+**Review stance:** 구현 전 설계·scope·파일 경로 리스크 검토
+
+## Summary
+
+Blog profile pages spec의 큰 방향은 적절하다. 현재 블로그가 Minimal Mistakes 샘플 상태에 가깝고, 첫 방문자가 사이트 주인의 현재 소속·연구 배경·연락처를 알기 어렵다는 문제 정의도 맞다. About / Experience / Research / Publications / Posts의 5탭 구성은 1차 콘텐츠 채움 범위로 충분하다.
+
+다만 현재 spec은 `docs/` 아래에 저장되어 있고, repo에도 Minimal Mistakes 샘플용 `docs/` 디렉터리가 그대로 남아 있다. 실제 블로그 루트 파일과 `docs/` 샘플 파일을 혼동할 여지가 크다. 또한 LinkedIn URL과 CV 상세 publication 데이터처럼 구현자가 추측하면 안 되는 정보가 아직 문서에 없다.
+
+구현 전에 아래 High 3건은 spec에 먼저 반영하는 것이 좋다.
+
+## Findings
+
+### 1. High — 구현 대상 경로가 root 기준인지 `docs/` 기준인지 혼동될 수 있다
+
+**위치**
+
+- Target spec: `구현 변경 사항`
+- Target spec: `페이지 메타데이터 규칙`
+- Current repo: root `_config.yml`
+- Current repo: `docs/_config.yml`, `docs/_pages/about.md`
+
+**문제**
+
+Target spec은 `docs/superpowers/specs/`에 있고, 새 파일 경로를 `_pages/about.md`, `_config.yml`, `_data/navigation.yml`처럼 상대 경로로 적고 있다. 그런데 현재 repo에는 Minimal Mistakes 샘플 사이트용 `docs/_config.yml`, `docs/_pages/about.md`, `docs/_data/navigation.yml`도 존재한다.
+
+실제 블로그는 repo root의 `_config.yml`, `_data/navigation.yml`, `index.html`, `_posts/`를 사용한다. root `_config.yml`에는 `/docs`가 exclude로 잡혀 있으므로, `docs/_pages`를 수정해도 실제 사이트에는 반영되지 않는다.
+
+이대로 plan이나 구현으로 넘어가면 구현자가 spec 위치를 기준으로 `docs/_pages` 샘플 파일을 고칠 위험이 있다.
+
+**권장 수정**
+
+Target spec에 구현 경로 기준을 명시한다.
+
+```text
+모든 구현 경로는 repo root(`/home/jykim/project/gitblog`) 기준이다.
+`docs/` 디렉터리는 Minimal Mistakes 샘플/문서 디렉터리이며 이번 구현 대상이 아니다.
+```
+
+그리고 파일 표도 root 기준임을 분명히 한다.
+
+```text
+_pages/about.md
+_pages/experience.md
+_pages/research.md
+_pages/publications.md
+assets/images/avatar.svg
+_config.yml
+_data/navigation.yml
+```
+
+### 2. High — LinkedIn URL과 publication 상세 데이터가 source로 고정되어 있지 않다
+
+**위치**
+
+- Target spec: `출처 자료`
+- Target spec: `합의된 결정 사항`
+- Target spec: `Publications`
+
+**문제**
+
+Spec은 LinkedIn 프로필 URL을 노출한다고 정했지만, 출처 자료에는 LinkedIn의 현 직장 텍스트만 있고 실제 URL은 없다. 또한 Publications 페이지는 "Journal Articles 4건", "Conference Proceedings 7건 + 7건", "Grants & Honors 3건"처럼 개수와 카테고리만 있고, 실제 제목·저자·venue·연도·DOI 여부가 없다.
+
+CV 원본 경로도 Windows 로컬 절대경로라 현재 repo 작업 환경에서 접근할 수 없다.
+
+이 상태에서 구현하면 다음 중 하나가 된다.
+
+- LinkedIn 링크를 비워 두거나 임의 검색으로 추측한다.
+- publication 항목을 개수만 맞춰 요약한다.
+- CV 접근 가능성을 전제로 구현자가 막힌다.
+
+모두 공개 프로필 페이지에는 부적절하다.
+
+**권장 수정**
+
+Spec에 구현 가능한 source data를 직접 붙인다.
+
+- LinkedIn profile URL을 정확히 기입한다. 아직 모르면 `Open Questions`로 남기고 1차 구현에서 LinkedIn 링크를 제외한다.
+- Publications / Conferences / Honors의 실제 항목을 spec에 모두 적는다.
+- CV 파일을 repo에 넣지 않을 계획이면, 구현자가 필요한 텍스트만 spec에 전사한다.
+
+민감정보 제외 정책은 유지하되, 공개할 학술 정보는 문서 자체에 source of truth로 남기는 편이 좋다.
+
+### 3. High — `_config.yml` 정리 범위가 author block에만 치우쳐 샘플/빈 링크가 남을 수 있다
+
+**위치**
+
+- Target spec: `수정할 파일`
+- Current repo: root `_config.yml`
+
+**문제**
+
+Spec은 `_config.yml`에서 subtitle, author block, `_pages` defaults를 수정한다고 한다. 하지만 현재 root `_config.yml`에는 author links 외에도 정리해야 할 값이 남아 있다.
+
+- author links에 URL 없는 Website/Twitter/Facebook 항목이 있다.
+- footer links에도 Twitter/Facebook/GitLab/Bitbucket 같은 빈 URL 항목이 있다.
+- Instagram은 현재 노출되지만 spec의 4개 링크 정책에는 없다.
+- `social.links`가 비어 있어 SEO social profile과 sidebar links가 어긋날 수 있다.
+- `analytics.google.anonymize_ip`에 `flase` 오타가 있다.
+
+Spec의 "4개 링크 표시" 검증만 따르면 author sidebar는 고쳐도 footer나 SEO metadata에 낡은 placeholder가 남을 수 있다.
+
+**권장 수정**
+
+`_config.yml` 변경 범위를 더 구체화한다.
+
+- `author.links`는 Email, GitHub, LinkedIn, ORCID만 남긴다.
+- `footer.links`도 동일 정책으로 맞추거나, footer에서는 GitHub/LinkedIn/ORCID 정도만 남긴다고 명시한다.
+- `social.name`, `social.links`를 공개 프로필과 일관되게 채운다.
+- Instagram을 유지할지 제외할지 결정한다. 현재 spec 기준이면 제외가 맞다.
+- `analytics.google.anonymize_ip: flase`는 `false`로 고친다.
+
+### 4. Medium — `_pages` default와 page front matter 정책을 하나로 고정하는 편이 낫다
+
+**위치**
+
+- Target spec: `수정할 파일`
+- Target spec: `페이지 메타데이터 규칙`
+- Current repo: root `_config.yml`
+
+**문제**
+
+Spec은 `_config.yml` defaults에 `_pages` 기본값이 없으면 추가한다고 하면서도, 각 page front matter에 `layout: single`, `author_profile: true`를 넣을 수 있다고 열어둔다.
+
+현재 root `_config.yml`에는 posts default만 있고 `_pages` default가 없다. 구현자가 일부 페이지에는 front matter를 넣고 일부는 defaults에 기대면 문서 스타일이 흔들릴 수 있다.
+
+**권장 수정**
+
+둘 중 하나를 명시적으로 선택한다. 추천은 `_config.yml` defaults에 `_pages`를 추가하는 방식이다.
+
+```yaml
+defaults:
+  - scope:
+      path: "_pages"
+      type: pages
+    values:
+      layout: single
+      author_profile: true
+```
+
+그러면 각 `_pages/*.md` front matter는 `title`, `permalink` 중심으로 단순하게 유지할 수 있다.
+
+### 5. Medium — About은 "새로 만들 파일"이 아니라 기존 placeholder 교체다
+
+**위치**
+
+- Target spec: `새로 만들 파일`
+- Current repo: root에는 `_pages/` 없음
+- Current repo: `docs/_pages/about.md`
+
+**문제**
+
+실제 root에는 아직 `_pages/`가 없으므로 root 기준으로는 새 파일이 맞다. 하지만 repo 안에는 `docs/_pages/about.md` 샘플이 이미 있다. 이 때문에 "새로 만들 파일"이라는 표현이 경로 혼동을 더 키운다.
+
+**권장 수정**
+
+Finding 1의 경로 기준 문구와 함께 다음을 추가한다.
+
+```text
+Root `_pages/` 디렉터리를 새로 만들고 root `_pages/about.md`를 생성한다.
+`docs/_pages/about.md`는 Minimal Mistakes 샘플 문서이므로 수정하지 않는다.
+```
+
+### 6. Low — 문서 상태값이 현재 요청 흐름과 맞지 않는다
+
+**위치**
+
+- Target spec: 문서 상단 metadata
+
+**문제**
+
+Status가 `Approved (pending user spec review)`로 되어 있다. "approved"와 "pending review"가 동시에 있어 상태가 애매하다.
+
+**권장 수정**
+
+현재 단계에서는 다음 중 하나가 더 명확하다.
+
+```text
+Status: Draft — pending review
+```
+
+리뷰 반영 후에는:
+
+```text
+Status: Approved — pending implementation
+```
+
+### 7. Low — 검증 절차에 build-only check가 있으면 빠른 실패를 잡기 쉽다
+
+**위치**
+
+- Target spec: `검증`
+- Current repo: `docker-compose.yml`
+
+**문제**
+
+Spec은 `docker compose up`으로 로컬 서버를 띄운 뒤 URL을 확인한다고 한다. 이 검증은 필요하지만, config/front matter 오류를 빠르게 확인하는 build-only step도 있으면 좋다.
+
+**권장 수정**
+
+검증에 다음을 추가한다.
+
+```text
+bundle exec jekyll build
+```
+
+Docker 환경만 사용할 경우:
+
+```text
+docker compose run --rm jekyll bundle exec jekyll build
+```
+
+그 뒤 `docker compose up`으로 렌더링과 네비게이션을 확인하면 된다.
+
+## Positive Notes
+
+- 5탭 구성은 현재 블로그의 첫 콘텐츠 채움 범위로 적절하다.
+- 주소, 전화번호, 추천인 연락처, 학교 이메일을 제외하기로 한 PII 정책은 안전하다.
+- 기존 dark skin과 Minimal Mistakes 기본 layout을 유지하고 콘텐츠만 채우는 방향은 scope가 작고 구현 리스크가 낮다.
+- Posts를 별도 페이지로 만들지 않고 root `/`의 기존 home layout을 유지하는 결정은 단순하다.
+
+## Recommended Next Step
+
+Plan 작성 또는 구현 전에 target spec에 아래 항목을 먼저 반영한다.
+
+1. 모든 구현 경로가 repo root 기준이며 `docs/` 샘플 사이트는 수정 대상이 아니라고 명시한다.
+2. LinkedIn URL과 publication/conference/honor 상세 항목을 spec에 직접 추가하거나, 미확정이면 Open Questions로 남긴다.
+3. `_config.yml` 정리 범위를 author links뿐 아니라 footer links, social metadata, 빈 placeholder 링크, `anonymize_ip` 오타까지 포함하도록 확장한다.
+4. `_pages` default와 page front matter 정책을 하나로 고정한다.
+5. Status를 `Draft — pending review` 또는 리뷰 반영 후 `Approved — pending implementation`로 정리한다.
+
+위 항목이 반영되면 이 spec은 profile pages 구현 plan의 기준 문서로 사용할 수 있다.

--- a/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
+++ b/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
@@ -1,8 +1,9 @@
 # Blog Profile Pages Design
 
 - **Date:** 2026-05-11
-- **Status:** Approved (pending user spec review)
+- **Status:** Draft — pending review
 - **Branch:** `feature/profile-pages`
+- **Reviews incorporated:** `2026-05-11-blog-profile-pages-design-review.md` (Codex)
 
 ## 목표
 
@@ -10,8 +11,17 @@
 
 ## 출처 자료
 
-- 학술 CV: `D:\Personal\01_커리어\경력 이직\2026 상반기 삼성전자 DX부문\지원서\CV_Jiyeon Kim.pdf` (2025-08 기준, 3 페이지)
+- 학술 CV: `D:\Personal\01_커리어\경력 이직\2026 상반기 삼성전자 DX부문\지원서\CV_Jiyeon Kim.pdf` (2025-08 기준, 3 페이지). 본 spec에 공개 가능한 항목을 전사함 — 원본 PDF가 구현 환경에서 접근 불가해도 spec 자체로 self-contained.
+- LinkedIn 프로필 URL: `https://www.linkedin.com/in/jiyeon-kim-b4ba19314/`
 - LinkedIn 현 직장 정보 (수동 제공): "Professional AI Scientist, LG CNS, Full-time, Jul 2025 – Present, Seoul · On-site, Project: Data Center Cooling Control AI Agent (Ongoing)"
+
+## 구현 경로 기준
+
+모든 구현 경로는 **repo root** (`/home/jykim/project/gitblog`) 기준이다.
+
+이 repo는 Minimal Mistakes 테마 소스 클론에 기반해서 `docs/` 디렉터리에 테마 자체 문서 사이트(`docs/_config.yml`, `docs/_pages/`, `docs/_data/navigation.yml` 등)가 그대로 남아있다. **`docs/` 하위는 이번 구현 대상이 아니다.**
+
+현재 root `_config.yml`의 `exclude:` 리스트에 `docs`가 빠져있어, 빌드 시 `docs/_pages/about.md`(permalink `/about/`)가 root와 충돌할 위험이 있다. 이번 작업에서 **`docs`를 exclude에 추가**한다 (수정할 파일 표 참조).
 
 ## 합의된 결정 사항
 
@@ -79,12 +89,40 @@
 
 ### Publications (`_pages/publications.md`)
 
-표준 학술 publications 페이지, 카테고리별 그룹.
+표준 학술 publications 페이지, 카테고리별 그룹. 본인 이름은 굵게(bold) 표시.
 
-- **Journal Articles** (4건: In Preparation 1, JFM 2024, Physics of Fluids 2022 공저, KSME Journal 2024 domestic)
-- **Conference Proceedings — International** (7건: APS DFD 75th/76th/77th, ICTAM 2024, TSFP12 — Jiyeon 1저자 5건 + 공저 2건)
-- **Conference Proceedings — Domestic** (7건: NCFE 12·13, KSME 2023, KSCSE 2022, KSCFE 2021, KSME Fluid Eng 2021·2023)
-- **Grants & Honors** (3건: Merit Academic Paper Award 2024, Graduate Scholarship 2021, CSE Best Poster 2nd 2021)
+**Journal Articles**
+
+1. **Jiyeon Kim**, Changhoon Lee. "Dynamics prediction of isotropic turbulence using conditional diffusion probabilistic models." (In Preparation)
+2. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of two-dimensional decaying turbulence using generative adversarial networks." *Journal of Fluid Mechanics*, Vol. 981, A19 (2024).
+3. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation modeling in wall-bounded turbulence." *Physics of Fluids*, Vol. 34, 105132 (2022).
+4. (Domestic) Changhoon Lee, **Jiyeon Kim**, Jun Park, Junhyuk Kim. THEME 03 "Utilization of artificial intelligence for turbulence analysis." *Journal of the KSME*, Vol. 64(4), 42–49 (2024).
+
+**Conference Proceedings — International**
+
+1. **Jiyeon Kim**, Changhoon Lee. "Prediction of isotropic turbulence using conditional diffusion probabilistic models." 77th APS DFD, Nov. 2024.
+2. **Jiyeon Kim**, Changhoon Lee. "A conditional diffusion model for prediction of 2D turbulence." ICTAM 2024, Aug. 2024.
+3. **Jiyeon Kim**, Changhoon Lee. "Application of denoising diffusion probabilistic models to turbulence prediction." 76th APS DFD, Nov. 2023.
+4. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D decaying turbulence using generative adversarial networks." 75th APS DFD, Nov. 2022.
+5. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of turbulent flows using deep learning." TSFP12, Jul. 2022.
+6. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation sub-grid scale modeling in turbulent channel flow." 75th APS DFD, Nov. 2022.
+7. Junhyuk Kim, Hyojin Kim, **Jiyeon Kim**, Changhoon Lee. "Deep reinforcement learning for large-eddy simulation of wall-bounded turbulence." TSFP12, Jul. 2022.
+
+**Conference Proceedings — Domestic**
+
+1. **Jiyeon Kim**, Changhoon Lee. "Turbulence prediction using conditional diffusion probabilistic models." 13th National Congress on Fluids Engineering (13NCFE), Jul. 2024.
+2. **Jiyeon Kim**, Changhoon Lee. "Application of denoising diffusion probabilistic model to turbulence problems." KSME Annual Meeting 2023, Nov. 2023.
+3. **Jiyeon Kim**, Changhoon Lee. "Effect of adversarial training to dynamics prediction of 2D turbulence." KSME Fluid Engineering Division 2023 Spring Conference, May 2023.
+4. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D decaying turbulence using generative adversarial networks." 12NCFE, Jun. 2022.
+5. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of 2D turbulence using deep learning." KSCSE 2022 Spring Conference, May 2022.
+6. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Prediction and control of turbulent flows using deep learning." KSME Fluid Engineering Division 2021 Spring Conference, Aug. 2021.
+7. **Jiyeon Kim**, Junhyuk Kim, Changhoon Lee. "Advanced prediction of 2D turbulent flows using deep learning." KSCFE 2021 Spring Conference, May 2021.
+
+**Grants & Honors**
+
+1. Merit Academic Paper Award — Academic Field of Natural Science, Jul. 2024.
+2. Graduate School Scholarship for Social Problem-Solving Courses — Design and Analysis of Energy System, Jun. 2021.
+3. 2021 CSE Best Poster Award — The Second Prize, May 2021.
 
 ### Posts (`/`)
 
@@ -92,54 +130,80 @@
 
 ## 구현 변경 사항
 
+모든 경로는 repo root 기준.
+
 ### 새로 만들 파일
 
 | 파일 | 용도 |
 |---|---|
-| `_pages/about.md` | About 페이지 |
+| `_pages/about.md` | About 페이지 (root `_pages/` 디렉터리부터 신규) |
 | `_pages/experience.md` | Experience 페이지 |
 | `_pages/research.md` | Research 페이지 |
 | `_pages/publications.md` | Publications 페이지 |
-| `assets/images/avatar.svg` | 'JK' 이니셜 아바타 SVG (`assets/images/` 디렉토리부터 신규 생성) |
+| `assets/images/avatar.svg` | 'JK' 이니셜 아바타 SVG (`assets/images/` 디렉터리부터 신규) |
 
 ### 수정할 파일
 
 | 파일 | 변경 |
 |---|---|
-| `_config.yml` | (1) `subtitle` 수정: `"A Belated Journal of Dr. Kim"`. (2) `author:` 블록 채우기 — `name`, `bio`(한 줄), `avatar` 경로, `location: "Seoul, Korea"`, `links` 4개 (Email/GitHub/LinkedIn/ORCID). (3) `defaults:` 블록 확인 — `_pages`에 `layout: single` + `author_profile: true` 기본값이 없으면 추가 |
+| `_config.yml` | (1) `subtitle` → `"A Belated Journal of Dr. Kim"` ("Prospective" 제거). (2) `author:` 블록 정리 — `name`(Jiyeon Kim 유지), `bio` 한 줄 갱신, `avatar: "/assets/images/avatar.svg"`, `location: "Seoul, Republic of Korea"` 유지, `email` 주석 유지, `links`는 **Email / GitHub / LinkedIn / ORCID 4개만 남김** (Website/Twitter/Facebook/Instagram 항목 삭제 — Instagram은 사용자 합의로 제외). (3) `footer.links`도 동일 정책 적용 — GitHub/LinkedIn/ORCID 정도만 남기고 Twitter/Facebook/GitLab/Bitbucket placeholder 삭제. (4) `social.name: "Jiyeon Kim"` 채움, `social.links`에 공개 프로필 URL(GitHub/LinkedIn/ORCID) 등록 — SEO structured data 일관성. (5) `analytics.google.anonymize_ip: flase` → `false` 오타 수정. (6) `exclude:` 리스트에 `docs` 추가 (테마 자체 문서 사이트가 root 빌드에 섞이지 않게). (7) `defaults:` 블록에 `_pages` 스코프 추가 — `layout: single` + `author_profile: true` 기본값. |
 | `_data/navigation.yml` | placeholder "Quick-Start Guide" 제거, 5탭 등록: `About → /about/`, `Experience → /experience/`, `Research → /research/`, `Publications → /publications/`, `Posts → /` |
 
 ### 건드리지 않을 것
 
 - 테마 코어 (`_includes`, `_layouts`, `_sass`) — 콘텐츠 추가만으로 충분
+- `docs/` 하위 일체 (`docs/_config.yml`, `docs/_pages/`, `docs/_data/` 등) — 테마 문서 사이트 샘플, 이번 작업과 무관. exclude로 빌드에서 제외만 함
 - 기존 테스트 포스트 (`_posts/2024-03-27-first-test-upload.md`) — 그대로 유지
 - 댓글 시스템(utterances) 설정 — 이미 `_config.yml`에 등록됨
 
 ## 페이지 메타데이터 규칙
 
-각 `_pages/*.md` 파일의 front matter는 다음 패턴을 따른다:
+`_config.yml`의 `defaults:` 블록에 `_pages` 스코프를 추가해 `layout: single` + `author_profile: true`를 기본값으로 고정한다.
+
+```yaml
+defaults:
+  - scope:
+      path: "_pages"
+      type: pages
+    values:
+      layout: single
+      author_profile: true
+```
+
+따라서 각 `_pages/*.md` front matter는 다음만 가진다:
 
 ```yaml
 ---
 title: "<Page Title>"
 permalink: /<slug>/
-layout: single
-author_profile: true
 ---
 ```
 
-`layout`/`author_profile`은 `_config.yml`의 `defaults:` 블록으로 기본값 잡으면 각 페이지 front matter에서 생략 가능. 구현 시 둘 중 어느 방식이 깔끔한지 본다.
+페이지별로 `layout`/`author_profile`을 front matter에 다시 적지 않는다 — 스타일 일관성 + 향후 일괄 수정 용이.
 
 ## 검증
 
-구현 완료 후 다음 확인:
+순서대로 확인 (빠른 실패 → 통합 확인):
 
-- `docker compose up`으로 로컬 서버 띄움
-- `http://localhost:4000/about/`, `/experience/`, `/research/`, `/publications/` 각각 200 응답 + 정상 렌더링
-- 상단 네비게이션에 5탭 표시
-- 사이드바 author profile에 이름/아바타/4개 링크 표시
-- 외부 링크(GitHub/LinkedIn/ORCID/mailto) 실제 URL 연결 확인
-- 빌드 로그에 새 에러 없음 (기존 sass deprecation warning은 무관)
+1. **Build-only check (빠른 실패)** — config/front matter 오류는 build 단계에서 즉시 잡힘:
+   ```
+   docker compose run --rm jekyll bundle exec jekyll build
+   ```
+   exit code 0 + 새 에러 없음 (기존 sass deprecation warning은 무관).
+2. **Serve + 페이지 응답**:
+   ```
+   docker compose up -d
+   curl -sI http://localhost:4000/{about,experience,research,publications}/ | head
+   ```
+   각 경로 HTTP 200.
+3. **렌더링 확인** (브라우저):
+   - 상단 네비게이션에 5탭(About/Experience/Research/Publications/Posts) 표시
+   - 사이드바 author profile에 이름/아바타(JK)/4개 링크(Email/GitHub/LinkedIn/ORCID) 표시 — Website/Twitter/Facebook/Instagram 흔적 없음
+   - Footer에 placeholder 링크 없음
+   - 외부 링크 4개 실제 URL 연결 확인 (`mailto:jykim3994@gmail.com`, `github.com/jiyeon914`, `linkedin.com/in/jiyeon-kim-b4ba19314`, `orcid.org/0000-0001-6668-1951`)
+4. **회귀 점검**:
+   - 홈(`/`) 여전히 정상, 기존 테스트 포스트(`_posts/2024-03-27-first-test-upload.md`)도 렌더됨
+   - `docs/` 하위 페이지(예: 테마 `/markup/`, `/category-archive/` 같은 샘플)가 빌드 결과(`_site/`)에 포함되지 않음
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
+++ b/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
@@ -1,0 +1,156 @@
+# Blog Profile Pages Design
+
+- **Date:** 2026-05-11
+- **Status:** Approved (pending user spec review)
+- **Branch:** `feature/profile-pages`
+
+## 목표
+
+`jiyeon914.github.io` (Minimal Mistakes 기반 Jekyll 블로그)에 사이트 주인의 프로필/이력 정보를 노출하는 페이지를 추가한다. 현재 사이트는 콘텐츠가 거의 비어있고 네비게이션은 theme 템플릿의 placeholder("Quick-Start Guide")만 남아있어, 첫 방문자가 사이트 주인이 누구인지 알 수 없다. 이번 작업은 *콘텐츠 1차 채움*에 해당하며, 추가 포스트 작성은 별도 작업.
+
+## 출처 자료
+
+- 학술 CV: `D:\Personal\01_커리어\경력 이직\2026 상반기 삼성전자 DX부문\지원서\CV_Jiyeon Kim.pdf` (2025-08 기준, 3 페이지)
+- LinkedIn 현 직장 정보 (수동 제공): "Professional AI Scientist, LG CNS, Full-time, Jul 2025 – Present, Seoul · On-site, Project: Data Center Cooling Control AI Agent (Ongoing)"
+
+## 합의된 결정 사항
+
+| 항목 | 결정 |
+|---|---|
+| 언어 | 영어 메인. About 페이지 상단에 한국어 짧은 인사말 추가 |
+| 페이지 구성 | 5탭 — About \| Experience \| Research \| Publications \| Posts |
+| 노출 PII | 이름, 학력, 연구이력, 이메일(`jykim3994@gmail.com`), ORCID(`0000-0001-6668-1951`), GitHub(`jiyeon914`), LinkedIn 프로필 URL |
+| 제외 | 주소, 전화번호, 추천인 연락처, 학교 이메일(접속 불가) |
+| 현 소속 반영 | PhD 완료 + LG CNS Professional AI Scientist 명시. Data Center Cooling Control AI Agent 프로젝트 언급 |
+| 아바타 | 'JK' 이니셜 SVG 플레이스홀더, `/assets/images/avatar.svg` |
+| 테마 스킨 | 기존 `dark` 유지 |
+| 서브타이틀 | `"A Belated Journal of Dr. Kim"` (기존 `"A Belated Journal of Prospective Dr. Kim"`에서 "Prospective" 제거) |
+| 브랜치 전략 | `feature/profile-pages` 단일 브랜치. 첫 커밋 = 스펙, 이후 커밋 = 구현. PR 하나로 통합 |
+
+## 페이지별 콘텐츠
+
+### About (`_pages/about.md`)
+
+페이지의 최소·기본 정보. 깊이는 다른 페이지에 위임.
+
+- 한국어 짧은 인사말 (2–3줄, 캐주얼 톤): 환영 + 사이트 목적 한 줄
+- English bio (3–5줄):
+  - 현재 LG CNS Professional AI Scientist, Data Center Cooling Control AI Agent 프로젝트
+  - PhD in Fluid Mechanics, Yonsei University (Aug 2025)
+  - "Bridging CFD and deep learning" 류의 한 줄 포지셔닝
+- 본문에 contact/links 인라인 (Email, ORCID, GitHub, LinkedIn). 사이드바와 중복되지만 본문 컨텍스트에서 한 번 더 명시.
+
+### Experience (`_pages/experience.md`)
+
+학력 + 직무를 시간순(역순) 정리하는 *개요* 페이지.
+
+- **Education**
+  - Ph.D. in Fluid Mechanics, Yonsei University (Mar 2020 – Aug 2025), advised by Changhoon Lee
+  - B.S. in Mechanical Engineering, Yonsei University (Mar 2012 – Feb 2020)
+- **Industry**
+  - Professional AI Scientist, LG CNS (Jul 2025 – Present), Seoul, Korea
+    - Project: Data Center Cooling Control AI Agent (Ongoing)
+- **Academic Research**
+  - Graduate Student Researcher, TURBULENCE Lab, Yonsei University (Mar 2020 – Aug 2025)
+    - CV의 4 bullets을 narrative 1–2 문장으로 압축
+  - Undergraduate Research Intern, TURBULENCE Lab, Yonsei University (Jan 2019 – Feb 2020)
+    - CV의 3 bullets 압축
+- **Teaching**
+  - CSE Undergraduate Research Program, CFD team instructor (Summer/Winter 2022, 2023)
+  - Teaching Assistant, Yonsei: MEU3009 (Winter 2022), MEU4400 (Spring 2024, Fall 2024)
+
+### Research (`_pages/research.md`)
+
+연구 주제·방법론 narrative. *무엇/어떻게/왜*에 초점.
+
+- **Research Interests** (CV 두 카테고리 확장)
+  - Fluid mechanics — turbulence, CFD, 통계적 성질 분석
+  - Deep learning — generative 모델, XAI, 시계열 물리 데이터 응용
+- **Topics**
+  - 2D & 3D homogeneous isotropic turbulence (DNS, LES)
+  - DL 모델 진화: CNN → U-Net → GAN → Diffusion model → FNO
+  - Scale-dependent analysis + XAI for turbulence prediction
+  - GPU-accelerated CFD
+- **Funded Projects**
+  - NRF Strategic Project, "Deep learning of turbulence" (Mar 2020 – Feb 2022), Participant
+  - NRF Mid-sized Research Project, "Fundamental understanding and high-performance modeling of turbulent flows using deep learning" (Mar 2022 – Present), Participant
+- **Industrial Bridge** (현재)
+  - Data Center Cooling Control AI Agent @ LG CNS — CFD/열관리 도메인 + AI를 실제 제품에 적용
+
+### Publications (`_pages/publications.md`)
+
+표준 학술 publications 페이지, 카테고리별 그룹.
+
+- **Journal Articles** (4건: In Preparation 1, JFM 2024, Physics of Fluids 2022 공저, KSME Journal 2024 domestic)
+- **Conference Proceedings — International** (7건: APS DFD 75th/76th/77th, ICTAM 2024, TSFP12 — Jiyeon 1저자 5건 + 공저 2건)
+- **Conference Proceedings — Domestic** (7건: NCFE 12·13, KSME 2023, KSCSE 2022, KSCFE 2021, KSME Fluid Eng 2021·2023)
+- **Grants & Honors** (3건: Merit Academic Paper Award 2024, Graduate Scholarship 2021, CSE Best Poster 2nd 2021)
+
+### Posts (`/`)
+
+기존 Minimal Mistakes 기본 홈(=포스트 리스트) 그대로 사용. 별도 페이지 생성 없음. 네비게이션 메뉴에서 `/`로 링크.
+
+## 구현 변경 사항
+
+### 새로 만들 파일
+
+| 파일 | 용도 |
+|---|---|
+| `_pages/about.md` | About 페이지 |
+| `_pages/experience.md` | Experience 페이지 |
+| `_pages/research.md` | Research 페이지 |
+| `_pages/publications.md` | Publications 페이지 |
+| `assets/images/avatar.svg` | 'JK' 이니셜 아바타 SVG (`assets/images/` 디렉토리부터 신규 생성) |
+
+### 수정할 파일
+
+| 파일 | 변경 |
+|---|---|
+| `_config.yml` | (1) `subtitle` 수정: `"A Belated Journal of Dr. Kim"`. (2) `author:` 블록 채우기 — `name`, `bio`(한 줄), `avatar` 경로, `location: "Seoul, Korea"`, `links` 4개 (Email/GitHub/LinkedIn/ORCID). (3) `defaults:` 블록 확인 — `_pages`에 `layout: single` + `author_profile: true` 기본값이 없으면 추가 |
+| `_data/navigation.yml` | placeholder "Quick-Start Guide" 제거, 5탭 등록: `About → /about/`, `Experience → /experience/`, `Research → /research/`, `Publications → /publications/`, `Posts → /` |
+
+### 건드리지 않을 것
+
+- 테마 코어 (`_includes`, `_layouts`, `_sass`) — 콘텐츠 추가만으로 충분
+- 기존 테스트 포스트 (`_posts/2024-03-27-first-test-upload.md`) — 그대로 유지
+- 댓글 시스템(utterances) 설정 — 이미 `_config.yml`에 등록됨
+
+## 페이지 메타데이터 규칙
+
+각 `_pages/*.md` 파일의 front matter는 다음 패턴을 따른다:
+
+```yaml
+---
+title: "<Page Title>"
+permalink: /<slug>/
+layout: single
+author_profile: true
+---
+```
+
+`layout`/`author_profile`은 `_config.yml`의 `defaults:` 블록으로 기본값 잡으면 각 페이지 front matter에서 생략 가능. 구현 시 둘 중 어느 방식이 깔끔한지 본다.
+
+## 검증
+
+구현 완료 후 다음 확인:
+
+- `docker compose up`으로 로컬 서버 띄움
+- `http://localhost:4000/about/`, `/experience/`, `/research/`, `/publications/` 각각 200 응답 + 정상 렌더링
+- 상단 네비게이션에 5탭 표시
+- 사이드바 author profile에 이름/아바타/4개 링크 표시
+- 외부 링크(GitHub/LinkedIn/ORCID/mailto) 실제 URL 연결 확인
+- 빌드 로그에 새 에러 없음 (기존 sass deprecation warning은 무관)
+
+## Out of Scope
+
+- 블로그 포스트 작성
+- 카테고리/태그 분류 체계 정의
+- 테마 색상/타이포그래피 커스터마이즈
+- 댓글 시스템 동작 확인 (첫 포스트 작성 시 별도 확인)
+- 분석 도구(Google Analytics 등) 추가
+- 다국어(한/영 전환) 본격 지원 — About 페이지 인사말 한 곳에만 한국어
+- GitHub Pages 배포 흐름 (별도 작업)
+
+## Open Questions
+
+없음 — 브레인스토밍에서 모두 합의됨.

--- a/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
+++ b/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
@@ -1,7 +1,7 @@
 # Blog Profile Pages Design
 
 - **Date:** 2026-05-11
-- **Status:** Draft — pending review
+- **Status:** Approved — pending implementation
 - **Branch:** `feature/profile-pages`
 - **Reviews incorporated:** `2026-05-11-blog-profile-pages-design-review.md` (Codex)
 

--- a/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
+++ b/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
@@ -21,7 +21,7 @@
 
 이 repo는 Minimal Mistakes 테마 소스 클론에 기반해서 `docs/` 디렉터리에 테마 자체 문서 사이트(`docs/_config.yml`, `docs/_pages/`, `docs/_data/navigation.yml` 등)가 그대로 남아있다. **`docs/` 하위는 이번 구현 대상이 아니다.**
 
-현재 root `_config.yml`의 `exclude:` 리스트에 `docs`가 빠져있어, 빌드 시 `docs/_pages/about.md`(permalink `/about/`)가 root와 충돌할 위험이 있다. 이번 작업에서 **`docs`를 exclude에 추가**한다 (수정할 파일 표 참조).
+root `_config.yml`의 `exclude:` 리스트에 이미 `- /docs # ignore Minimal Mistakes /docs`가 등록되어 있어 (line 185), `docs/_pages/about.md` 등은 빌드에서 제외된다. 이번 작업에서 추가 exclude 변경은 필요 없다.
 
 ## 합의된 결정 사항
 
@@ -146,7 +146,7 @@
 
 | 파일 | 변경 |
 |---|---|
-| `_config.yml` | (1) `subtitle` → `"A Belated Journal of Dr. Kim"` ("Prospective" 제거). (2) `author:` 블록 정리 — `name`(Jiyeon Kim 유지), `bio` 한 줄 갱신, `avatar: "/assets/images/avatar.svg"`, `location: "Seoul, Republic of Korea"` 유지, `email` 주석 유지, `links`는 **Email / GitHub / LinkedIn / ORCID 4개만 남김** (Website/Twitter/Facebook/Instagram 항목 삭제 — Instagram은 사용자 합의로 제외). (3) `footer.links`도 동일 정책 적용 — GitHub/LinkedIn/ORCID 정도만 남기고 Twitter/Facebook/GitLab/Bitbucket placeholder 삭제. (4) `social.name: "Jiyeon Kim"` 채움, `social.links`에 공개 프로필 URL(GitHub/LinkedIn/ORCID) 등록 — SEO structured data 일관성. (5) `analytics.google.anonymize_ip: flase` → `false` 오타 수정. (6) `exclude:` 리스트에 `docs` 추가 (테마 자체 문서 사이트가 root 빌드에 섞이지 않게). (7) `defaults:` 블록에 `_pages` 스코프 추가 — `layout: single` + `author_profile: true` 기본값. |
+| `_config.yml` | (1) `subtitle` → `"A Belated Journal of Dr. Kim"` ("Prospective" 제거). (2) `author:` 블록 정리 — `name`(Jiyeon Kim 유지), `bio` 한 줄 갱신, `avatar: "/assets/images/avatar.svg"`, `location: "Seoul, Republic of Korea"` 유지, `email` 주석 유지, `links`는 **Email / GitHub / LinkedIn / ORCID 4개만 남김** (Website/Twitter/Facebook/Instagram 항목 삭제 — Instagram은 사용자 합의로 제외). (3) `footer.links`도 동일 정책 적용 — GitHub/LinkedIn/ORCID 정도만 남기고 Twitter/Facebook/GitLab/Bitbucket placeholder 삭제. (4) `social.name: "Jiyeon Kim"` 채움, `social.links`에 공개 프로필 URL(GitHub/LinkedIn/ORCID) 등록 — SEO structured data 일관성. (5) `analytics.google.anonymize_ip: flase` → `false` 오타 수정. (6) `defaults:` 블록에 `_pages` 스코프 추가 — `layout: single` + `author_profile: true` 기본값. (`exclude:`에 `/docs`는 이미 등록되어 있어 별도 변경 없음.) |
 | `_data/navigation.yml` | placeholder "Quick-Start Guide" 제거, 5탭 등록: `About → /about/`, `Experience → /experience/`, `Research → /research/`, `Publications → /publications/`, `Posts → /` |
 
 ### 건드리지 않을 것

--- a/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
+++ b/docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
@@ -11,7 +11,7 @@
 
 ## 출처 자료
 
-- 학술 CV: `D:\Personal\01_커리어\경력 이직\2026 상반기 삼성전자 DX부문\지원서\CV_Jiyeon Kim.pdf` (2025-08 기준, 3 페이지). 본 spec에 공개 가능한 항목을 전사함 — 원본 PDF가 구현 환경에서 접근 불가해도 spec 자체로 self-contained.
+- 학술 CV (2025-08 기준, 3 페이지 PDF, 로컬 보관). 본 spec에 공개 가능한 항목을 전사함 — 원본 PDF가 구현 환경에서 접근 불가해도 spec 자체로 self-contained.
 - LinkedIn 프로필 URL: `https://www.linkedin.com/in/jiyeon-kim-b4ba19314/`
 - LinkedIn 현 직장 정보 (수동 제공): "Professional AI Scientist, LG CNS, Full-time, Jul 2025 – Present, Seoul · On-site, Project: Data Center Cooling Control AI Agent (Ongoing)"
 


### PR DESCRIPTION
## Summary

- Adds a 5-tab profile structure (About | Experience | Research | Publications | Posts) on top of the existing Minimal Mistakes 4.24 theme — the site no longer shows only a placeholder "Quick-Start Guide" link.
- Cleans up `_config.yml`: subtitle ("Prospective" removed), sidebar/footer links scoped to the 4 approved channels (Email / GitHub / LinkedIn / ORCID), SEO `social:` block filled, `_pages` added to `defaults:`, `anonymize_ip: flase` typo fixed.
- Adds a 'JK' initials placeholder avatar SVG (replaceable with a real photo later).
- Rewires the top navigation to the new pages.

Spec: docs/superpowers/specs/2026-05-11-blog-profile-pages-design.md
Plan: docs/superpowers/plans/2026-05-11-profile-pages.md

## Test plan

- [ ] docker compose run --rm jekyll bundle exec jekyll build — exit 0, no new errors
- [ ] docker compose up — http://localhost:4000/{about,experience,research,publications}/ all return 200
- [ ] Sidebar shows JK avatar + Email / GitHub / LinkedIn / ORCID only (no Twitter / Facebook / Instagram leftover)
- [ ] Footer shows GitHub / LinkedIn / ORCID only
- [ ] About page renders Korean greeting + English bio + contact section
- [ ] Publications lists all 21 entries across 4 sections
- [ ] Home (/) still lists the existing test post

🤖 Generated with [Claude Code](https://claude.com/claude-code)