### PR TITLE
Add agent instructions (AGENTS.md, CLAUDE.md) and pr_cycle.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent Instructions
+
+This file is the project-level entry point for coding agents. Keep it short, operational, and specific to this repository.
+
+## Read First
+
+- [README.md](README.md) for the project identity.
+- [_config.yml](_config.yml) for site-wide Jekyll and Minimal Mistakes settings.
+- [_data/navigation.yml](_data/navigation.yml) before changing top navigation.
+- Relevant files under `_pages/`, `_posts/`, `assets/`, `_includes/`, `_layouts`, and `_sass/` for the touched area.
+
+## Project Context
+
+- This is the public GitHub Pages repository for `jiyeon914.github.io`.
+- The site is a Jekyll blog based on Minimal Mistakes 4.24.0, with theme files vendored in the repo.
+- Root-level Jekyll files are the live site source.
+- It is fine to create project documentation under `docs/`, such as specs, plans, reviews, and journals.
+- Do not accidentally restore the old Minimal Mistakes upstream sample `docs/` site or theme-development `test/` fixture tree when making unrelated changes. Reintroduce those deleted upstream files only if the user explicitly asks or a current toolchain genuinely requires them.
+- Current primary content is a personal academic and professional profile: About, Experience, Research, Publications, and Posts.
+
+## Environment
+
+- Prefer Docker for Ruby, Bundler, and Jekyll commands. Do not require host-level Ruby/Jekyll installs for normal work.
+- This is not a Python project. Do not add a Python virtual environment, `pyproject.toml`, or Python tooling unless the user explicitly introduces a Python-based workflow.
+- `Gemfile.lock`, `_site/`, `.jekyll-cache/`, and `.jekyll-metadata` are local build artifacts and are ignored.
+- Docker Compose uses a named `bundle_cache` volume for installed gems, so gem installation should stay outside the repository tree.
+
+## Hard Rules
+
+- Treat this as a public repository. Do not commit private local filesystem paths, application-material context, phone numbers, home addresses, private CV files, secrets, analytics credentials beyond already-public config, or unreviewed personal data.
+- Keep source material references generic unless the user explicitly wants a public citation.
+- Do not add generated site output from `_site/`, Jekyll caches, logs, or local build artifacts.
+- Do not delete or rewrite user-authored content, profile pages, posts, or local agent settings unless explicitly asked.
+- Keep Minimal Mistakes customizations scoped. Prefer content/config changes over theme core edits when possible.
+- If work uncovers an out-of-scope issue, mention it to the user or record it in the relevant spec/review note instead of silently widening the patch.
+
+## Workflow Expectations
+
+- Keep changes small and directly tied to the user's request.
+- Before larger content or layout changes, check whether there is an active spec or PR discussion.
+- Preserve a clear reasoning trail in spec/review docs when decisions affect public profile content, privacy, navigation, or deployment behavior.
+- Write GitHub PR titles, bodies, review comments, and merge notes in Korean unless the user requests otherwise.
+- Be careful with branch state. This repo may have user changes; do not revert unrelated work.
+
+## Verification
+
+- For content/config changes, run a Docker-based Jekyll build when practical:
+
+  ```sh
+  docker compose run --rm jekyll bundle exec jekyll build
+  ```
+
+- If the user has intentionally installed Ruby/Bundler on the host, the equivalent host command is:
+
+  ```sh
+  bundle exec jekyll build
+  ```
+
+- For rendered-page checks, run:
+
+  ```sh
+  docker compose up
+  ```
+
+  Then verify relevant pages on `http://localhost:4000/`.
+
+- If verification cannot be run, state exactly why and what remains unverified.
+
+## Git Policy
+
+- Keep commits focused and avoid committing unrelated user changes.
+- Before committing, inspect `git status --short` and stage only the intended files.
+- Do not commit `_site/`, `.jekyll-cache/`, `.jekyll-metadata`, or local-only settings.
+- Use concise commit messages, for example `docs: add agent instructions` or `site: update profile navigation`.
+- Default merge strategy: **merge commit** via `gh pr merge <num> --merge --delete-branch`. Preserve the feature-branch story when it is useful for history.
+- Use **squash merge** only when intermediate commits contain sensitive content (private paths, personal context, secrets) that should not enter `main`'s history. This is an exception, not the default.
+- Never force-push to `main`. Force-push on feature branches only when explicitly requested.
+- For the repeated branch → commit → push → PR → review → merge → prune flow, use `scripts/pr_cycle.sh` so Claude and Codex follow the same pattern. See `scripts/pr_cycle.sh --help` for usage.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working with this repository.
+
+The substantive operating rules are shared with other agents:
+
+- [AGENTS.md](AGENTS.md) is the project-level entry point for hard rules, workflow expectations, verification, and git policy.
+- [_config.yml](_config.yml) defines the live Jekyll site configuration.
+- [_data/navigation.yml](_data/navigation.yml) defines the top navigation.
+
+## Claude-specific notes
+
+- Project-level Claude permissions live in `.claude/`.
+- If user-level memory conflicts with this repository's files, the repository files are authoritative for project behavior.
+- This is a public GitHub Pages repository. Apply the privacy rules in [AGENTS.md](AGENTS.md) before committing documentation or profile content.

--- a/scripts/pr_cycle.sh
+++ b/scripts/pr_cycle.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/pr_cycle.sh run \
+    --branch <branch-name> \
+    --commit <commit-message> \
+    --title <pr-title> \
+    --body-file <markdown-file> \
+    [--review-file <markdown-file>] \
+    [--base main] \
+    [--add <path>]... \
+    [--merge]
+
+Purpose:
+  Automate the repeated local flow:
+  branch -> stage explicit paths -> commit -> push -> create PR -> optional review
+  -> optional merge commit -> fetch --prune.
+
+Notes:
+  - Use --add for every file/path that should be staged.
+  - If --add is omitted, the script uses the current staged changes.
+  - --merge is intentionally explicit because it updates main.
+  - PRs are merged with merge commits only, matching this repo's policy.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+run_cmd() {
+  echo "+ $*" >&2
+  "$@"
+}
+
+mode="${1:-}"
+if [[ "$mode" == "-h" || "$mode" == "--help" || -z "$mode" ]]; then
+  usage
+  exit 0
+fi
+[[ "$mode" == "run" ]] || die "unknown mode: $mode"
+shift
+
+branch=""
+base="main"
+commit_msg=""
+title=""
+body_file=""
+review_file=""
+merge_after=0
+add_paths=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)
+      branch="${2:-}"; shift 2 ;;
+    --base)
+      base="${2:-}"; shift 2 ;;
+    --commit)
+      commit_msg="${2:-}"; shift 2 ;;
+    --title)
+      title="${2:-}"; shift 2 ;;
+    --body-file)
+      body_file="${2:-}"; shift 2 ;;
+    --review-file)
+      review_file="${2:-}"; shift 2 ;;
+    --add)
+      add_paths+=("${2:-}"); shift 2 ;;
+    --merge)
+      merge_after=1; shift ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$branch" ]] || die "--branch is required"
+[[ -n "$commit_msg" ]] || die "--commit is required"
+[[ -n "$title" ]] || die "--title is required"
+[[ -n "$body_file" ]] || die "--body-file is required"
+[[ -f "$body_file" ]] || die "--body-file does not exist: $body_file"
+if [[ -n "$review_file" && ! -f "$review_file" ]]; then
+  die "--review-file does not exist: $review_file"
+fi
+
+need_cmd git
+need_cmd gh
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" != "$branch" ]]; then
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    run_cmd git switch "$branch"
+  else
+    run_cmd git switch -c "$branch"
+  fi
+fi
+
+if [[ ${#add_paths[@]} -gt 0 ]]; then
+  run_cmd git add "${add_paths[@]}"
+fi
+
+if git diff --cached --quiet; then
+  die "no staged changes. Pass --add <path> or stage changes before running."
+fi
+
+run_cmd git diff --cached --stat
+run_cmd git commit -m "$commit_msg"
+run_cmd git push -u origin "$branch"
+
+pr_url="$(gh pr create \
+  --base "$base" \
+  --head "$branch" \
+  --title "$title" \
+  --body-file "$body_file")"
+echo "$pr_url"
+
+pr_number="$(gh pr view "$branch" --json number --jq '.number')"
+[[ -n "$pr_number" ]] || die "could not determine PR number"
+
+if [[ -n "$review_file" ]]; then
+  run_cmd gh pr review "$pr_number" --comment --body-file "$review_file"
+fi
+
+if [[ "$merge_after" -eq 1 ]]; then
+  run_cmd gh pr merge "$pr_number" --merge --delete-branch
+  run_cmd git fetch --prune
+  run_cmd git switch "$base"
+  run_cmd git merge --ff-only "origin/$base"
+fi
+
+run_cmd git status --short --branch


### PR DESCRIPTION
## 요약

Claude Code / Codex 같은 코딩 에이전트가 이 리포에서 일관된 규칙으로 동작하도록 `AGENTS.md`, `CLAUDE.md`를 추가하고, 반복적인 PR 워크플로 자동화 스크립트 `scripts/pr_cycle.sh`를 함께 가져옵니다.

## 출처와 범위

- Codex가 auto-trading 프로젝트의 동일 파일들을 참고해서 1차 드래프트를 만들었습니다 (KIS/Python/risk-manager 등 프로젝트 특수 항목은 제거된 상태).
- 본 PR은 그 드래프트를 검토하고, gitblog 워크플로에 맞춰 *Git Policy* 영역을 보강했습니다.

## 변경 내역

- \`AGENTS.md\` (신규): Read First / Project Context / Environment / Hard Rules / Workflow / Verification / Git Policy
- \`CLAUDE.md\` (신규): AGENTS.md 포인터 + Claude 전용 메모
- \`scripts/pr_cycle.sh\` (신규): branch → commit → push → PR → optional review → optional merge → prune를 한 명령으로 묶는 스크립트. auto-trading에서 그대로 가져왔습니다 (실행 권한 포함).

## Git Policy 보강 포인트

코덱스 드래프트가 기본 규칙만 두고 머지 전략을 명시하지 않아서, 최근 두 PR 경험을 정책으로 명문화:

- **기본 merge 전략 = merge commit** (\`gh pr merge <num> --merge --delete-branch\`).
- **Squash는 예외** — 중간 커밋에 *민감 데이터*가 들어있어 main 히스토리에 남기면 안 될 때만. (PR #1에서 적용했던 사유와 동일)
- main 강제 푸시 금지.
- 반복 워크플로는 \`scripts/pr_cycle.sh\` 사용.

## Test plan

- [ ] \`AGENTS.md\` / \`CLAUDE.md\` 빌드와 무관. Jekyll 빌드 영향 없음을 \`docker compose run --rm jekyll bundle exec jekyll build\`로 확인.
- [ ] \`scripts/pr_cycle.sh --help\` 출력이 정상.
- [ ] 다음 PR부터는 \`pr_cycle.sh run --branch ... --merge\` 호출로 동일 흐름 재현 가능 (실사용은 별도 PR에서 검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)