### PR TITLE
docs: README를 본인 블로그용으로 재작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# jiyeon914.github.io
+# Jiyeon's Voyage
+
+Personal blog at [jiyeon914.github.io](https://jiyeon914.github.io) — a slow-paced journal where I record research notes, reading, and bits of work as an AI Scientist (LG CNS) with a Ph.D. in fluid mechanics.
+
+## Stack
+
+- Jekyll 4 + Minimal Mistakes 4.24 (theme files vendored in this repo)
+- Hosted on GitHub Pages
+- Comments via [utterances](https://utteranc.es)
+
+## Local development
+
+The repository ships a Docker setup, so no host-level Ruby/Bundler install is required.
+
+```sh
+docker compose up
+```
+
+Then open `http://localhost:4000`. The first run pulls `ruby:3.2` and installs ~30 gems (5–10 minutes); subsequent runs start in seconds because the bundle cache lives in a named Docker volume.
+
+Build-only check (no server):
+
+```sh
+docker compose run --rm jekyll bundle exec jekyll build
+```
+
+## Repo layout
+
+- `_config.yml` — site-wide settings (title, author, navigation defaults, exclusions)
+- `_data/navigation.yml` — top-bar tabs
+- `_pages/` — standalone pages (About / Experience / Research / Publications)
+- `_posts/` — blog entries
+- `assets/css/main.scss` — site-level CSS overrides on top of Minimal Mistakes defaults
+- `_includes/`, `_layouts/`, `_sass/` — theme core, vendored from Minimal Mistakes
+- `scripts/pr_cycle.sh` — automation for the recurring branch → commit → push → PR → review → merge → prune workflow
+- `docs/superpowers/` — design specs, implementation plans, and review notes for non-trivial changes
+- `AGENTS.md`, `CLAUDE.md` — operating rules shared by coding agents (Codex, Claude Code)
+
+## Credits
+
+Built on the [Minimal Mistakes](https://github.com/mmistakes/minimal-mistakes) theme by Michael Rose, distributed under the MIT License. Theme source files are vendored into this repo (`_includes/`, `_layouts/`, `_sass/`, `assets/`); see [`LICENSE`](LICENSE) for the upstream license.
+
+Site content © Jiyeon Kim.


### PR DESCRIPTION
## 요약

루트의 `README.md`가 한 줄짜리 (`# jiyeon914.github.io`)였던 걸 본인 블로그 정체성에 맞게 재작성합니다.

## 변경 내역

- 사이트 이름 / URL / 한 줄 설명
- Stack (Jekyll 4 + MM 4.24, GitHub Pages, utterances)
- 로컬 개발 가이드 (Docker compose 워크플로)
- 리포 레이아웃 안내 (`_config.yml`, `_pages/`, `_posts/`, `scripts/pr_cycle.sh`, `docs/superpowers/`, `AGENTS.md` 등 주요 디렉터리/파일 한 줄 설명)
- Credits: Minimal Mistakes 테마 MIT attribution

## Test plan

- README는 빌드 영향 없음 (Jekyll publish 대상 아님 — 라이브 사이트 변경 없음)
- GitHub 리포 첫 페이지에서 새 README가 정상 렌더링되는지만 확인

## Workflow note

본 PR은 `scripts/pr_cycle.sh`의 첫 실사용 — PR #3에서 추가했던 자동화 스크립트로 brunch → commit → push → PR create → merge → fetch --prune → main FF 흐름을 한 명령으로 처리합니다.
